### PR TITLE
Fixes to setup.py

### DIFF
--- a/prescient/simulator/time_manager.py
+++ b/prescient/simulator/time_manager.py
@@ -7,8 +7,8 @@
 #  This software is distributed under the Revised BSD License.
 #  ___________________________________________________________________________
 
-from .manager import _Manager
 from __future__ import annotations
+from .manager import _Manager
 import dateutil
 import sys
 import datetime

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ if sys.version[0] == '2':
     print("Error: This package must be installed with python3")
     sys.exit(1)
 
-from setuptools import find_packages, setup
+from setuptools import setup, find_namespace_packages
 
-packages = find_packages()
+packages = find_namespace_packages(include=['prescient.*'])
 
-setup(name='Prescient',
+setup(name='prescient',
       version='2.0',
       description='Power Generation Scenario creation and simulation utilities',
       url='https://github.com/jwatsonnm/prescient',
@@ -37,6 +37,7 @@ setup(name='Prescient',
                 'prescient.py = prescient.simulator.prescient:main'
             ]
         },
+      package_data={'prescient.downloaders.rts_gmlc_prescient':['runners/*.txt','runners/templates/*']},
       install_requires=['numpy','matplotlib','pandas','scipy','pyomo','six',
                         'pyutilib', 'python-dateutil', 'networkx']
      )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='prescient',
                 'populator.py = prescient.scripts.populator:main',
                 'scenario_creator.py = prescient.scripts.scenario_creator:main',
                 'simulator.py = prescient.scripts.simulator:main',
-                'prescient.py = prescient.simulator.prescient:main'
+                #'prescient.py = prescient.simulator.prescient:main'
             ]
         },
       package_data={'prescient.downloaders.rts_gmlc_prescient':['runners/*.txt','runners/templates/*']},


### PR DESCRIPTION
Some of our new code uses implied modules (folders that don't have an __init__.py but are supposed to be modules anyway).  We had to make adjustments to get it to handle this.  Also, the downloaders didn't work if you did a real install rather than a develop install.