### PR TITLE
Plugin support

### DIFF
--- a/prescient/plugins/__init__.py
+++ b/prescient/plugins/__init__.py
@@ -1,0 +1,1 @@
+from .plugin_registration import *

--- a/prescient/plugins/__init__.py
+++ b/prescient/plugins/__init__.py
@@ -1,1 +1,16 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .internal import PluginCallbackManager
+
+def get_active_plugin_manager() -> PluginCallbackManager:
+    '''
+    Get the active plugin manager, creating one if necessary
+    '''
+    from . import internal
+    if internal.active_plugin_manager is None:
+        internal.active_plugin_manager = internal.PluginCallbackManager()
+    return internal.active_plugin_manager
+
 from .plugin_registration import *
+

--- a/prescient/plugins/internal.py
+++ b/prescient/plugins/internal.py
@@ -1,0 +1,4 @@
+# Code that is not intended to be called by plugins
+
+# The parser instance affect by plugins modifications
+active_parser = None

--- a/prescient/plugins/internal.py
+++ b/prescient/plugins/internal.py
@@ -2,3 +2,50 @@
 
 # The parser instance affect by plugins modifications
 active_parser = None
+
+# The instance of the PluginCallbackManager that handles
+# calls to plugin_registration methods
+active_plugin_manager = None
+
+# stats callbacks registered by plugins but not yet
+# added as subscribers
+pending_hourly_subscribers = []
+pending_daily_subscribers = []
+pending_overall_subscribers = []
+
+class PluginCallbackManager():
+    '''
+    Keeps track of what callback methods have been registered, and 
+    provides methods to invoke callbacks at appropriate times.
+    '''
+    def __init__(self):
+        self._options_preview_callbacks = []
+        self._initialization_callbacks = []
+
+    ### Registration methods ###
+    def register_options_preview_callback(self, callback):
+        self._options_preview_callbacks.append(callback)
+
+    def register_initialization_callback(self, callback):
+        self._initialization_callbacks.append(callback)
+
+
+    ### Callback invocation methods ###
+    def invoke_options_preview_callbacks(self, options):
+        for cb in self._options_preview_callbacks:
+            cb(options)
+
+    def invoke_initialization_callbacks(self, options, simulator):
+        for cb in self._initialization_callbacks:
+            cb(options, simulator)
+        # As part of initialization, we also register stats
+        # callbacks as subscribers
+        for s in pending_hourly_subscribers:
+            simulator.stats_manager.register_for_hourly_stats(s)
+        pending_hourly_subscribers.clear()
+        for s in pending_daily_subscribers:
+            simulator.stats_manager.register_for_daily_stats(s)
+        pending_daily_subscribers.clear()
+        for s in pending_overall_subscribers:
+            simulator.stats_manager.register_for_overall_stats(s)
+        pending_overall_subscribers.clear()

--- a/prescient/plugins/plugin_registration.py
+++ b/prescient/plugins/plugin_registration.py
@@ -1,0 +1,10 @@
+from optparse import Option
+
+def add_custom_commandline_option(option: Option) -> None:
+    '''
+    To add custom command-line options to Prescient, create a file that
+    calls this function and include that file as a plugin on the command
+    line (--plugin=my_file).
+    '''
+    from .internal import active_parser
+    active_parser.add_option(option)

--- a/prescient/plugins/plugin_registration.py
+++ b/prescient/plugins/plugin_registration.py
@@ -1,4 +1,12 @@
-from optparse import Option
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from optparse import Option
+    from typing import Callable
+    from prescient.simulator.options import Options
+    from prescient.stats import DailyStats, HourlyStats, OverallStats
+    from prescient.simulator.simulator import Simulator
+from . import get_active_plugin_manager
 
 def add_custom_commandline_option(option: Option) -> None:
     '''
@@ -8,3 +16,133 @@ def add_custom_commandline_option(option: Option) -> None:
     '''
     from .internal import active_parser
     active_parser.add_option(option)
+
+   
+def register_for_hourly_stats(callback: Callable[[HourlyStats], None]) -> None:
+    '''
+    Called during plugin registration to request a subscription to hourly stats updates.
+
+    To subscribe to statistics after plugin registration, call the stats_manager directly.
+    '''
+    from .internal import pending_hourly_subscribers
+    pending_hourly_subscribers.append(callback)
+
+def register_for_daily_stats(callback: Callable[[DailyStats], None]) -> None:
+    '''
+    Called during plugin registration to request a subscription to hourly stats updates
+
+    To subscribe to statistics after plugin registration, call the stats_manager directly.
+    '''
+    from .internal import pending_daily_subscribers
+    pending_daily_subscribers.append(callback)
+
+def register_for_overall_stats(callback: Callable[[OverallStats], None]) -> None:
+    '''
+    Called during plugin registration to request a subscription to the final overall stats update
+
+    To subscribe to statistics after plugin registration, call the stats_manager directly.
+    '''
+    from .internal import pending_overall_subscribers
+    pending_overall_subscribers.append(callback)
+
+def register_options_preview_callback(callback: Callable[[Options], None]) -> None:
+    ''' Request a method be called after options have been parsed, but before they
+        have been used to initialize simulation objects.
+    '''
+    get_active_plugin_manager().register_options_preview_callback(callback)
+
+def register_initialization_callback(callback: Callable[[Options, Simulator], None]) -> None:
+    ''' Request a method be called after options have been parsed, but before they
+        have been used to initialize simulation objects.
+    '''
+    get_active_plugin_manager().register_initialization_callback(callback)
+
+
+
+
+### Placeholders for future callbacks
+
+def register_before_ruc_generation_callback(callback):
+    ''' Register a callback to be called just before each new RUC pair is generated.
+
+        The callback will be called once for each forecast/actuals RUC pair.  It is
+        called before the RUC generation process has started.
+    '''
+    pass
+
+def register_before_new_forecast_ruc_callback(callback):
+    ''' Register a callback to be called just before a forecast RUC is generated.
+
+        The callback will be called once for each forecast RUC.  It is called after
+        initial conditions have been identified (i.e., the projected_sced is available),
+        but before the forecast RUC is created and solved.
+    '''
+    pass
+
+def register_before_new_actuals_ruc_callback(callback):
+    ''' Register a callback to be called just before an actuals RUC is generated.
+
+        The callback will be called once for each actuals RUC.  It is called after
+        the corresponding forecast RUC has been created and solved, but before the 
+        actuals RUC is created and solved.
+    '''
+    pass
+
+def register_after_ruc_generation_callback(callback):
+    ''' Register a callback to be called after each new RUC pair is generated.
+
+        The callback is called after both the forecast and actuals RUCs have been 
+        generated, just before they are stored in the DataManager.
+    '''
+    pass
+
+def register_before_ruc_activation_callback(callback):
+    ''' Register a callback to be called before activating a RUC.
+
+        The callback is called just before the most recently generated RUC
+        pair becomes the active RUC pair.
+    '''
+    pass
+
+def register_after_ruc_activation_callback(callback):
+    ''' Register a callback to be called after activating a RUC.
+
+        We probably don't need this one; before activation is probably enough.
+        All activation really does is swap some pointers.
+
+        The callback is called just after the most recently generated RUC
+        pair becomes the active RUC pair.
+    '''
+    pass
+
+def register_before_operations_callback(callback):
+    ''' Register a callback to be called before an operations model is created and solved.
+
+        Called just before an operations model is created and solved.  The active RUC is
+        already in place.
+    '''
+
+def register_dispatch_level_provider(callback):
+    ''' Register a method that provides requested dispatch levels.
+
+        This one has a different flavor than the other callbacks.  Prescient "pulls" the
+        requested values from the callback, rather than the callback "pushing" data into
+        the model when given the opportunity.  It's here as a discussion point, as some
+        have expressed a preference for pull-style code over push-style code.
+    '''
+    pass
+
+def register_after_operations_callback(callback):
+    ''' Register a callback to be called after the operations model has been created and
+        solved, but before the LMP has been solved, and before statistics have been 
+        collected.
+    '''
+    pass
+
+def register_after_lmp_callback(callback):
+    ''' Register a callback to be called after the LMP has been calculated.
+
+        Called after the LMP model has been solved, but before operations and LMP
+        statistics have been collected.
+    '''
+    pass

--- a/prescient/simulator/data_manager.py
+++ b/prescient/simulator/data_manager.py
@@ -28,6 +28,7 @@ class DataManager(_Manager):
         self.ruc_instance_to_simulate_next_period = None
         self.deterministic_ruc_instance_for_this_period = None
         self.deterministic_ruc_instance_for_next_period = None
+        self.extensions = {}
 
     def update_time(self, time):
         '''This takes a Time object and makes the appropiate updates to the data'''
@@ -141,3 +142,7 @@ class DataManager(_Manager):
     @property
     def renewables_forecast_error(self):
         return self._renewables_forecast_error
+
+    @property
+    def extensions(self):
+        return self._extensions

--- a/prescient/simulator/data_manager.py
+++ b/prescient/simulator/data_manager.py
@@ -28,7 +28,7 @@ class DataManager(_Manager):
         self.ruc_instance_to_simulate_next_period = None
         self.deterministic_ruc_instance_for_this_period = None
         self.deterministic_ruc_instance_for_next_period = None
-        self.extensions = {}
+        self._extensions = {}
 
     def update_time(self, time):
         '''This takes a Time object and makes the appropiate updates to the data'''

--- a/prescient/simulator/prescient.py
+++ b/prescient/simulator/prescient.py
@@ -25,6 +25,7 @@ from .oracle_manager import OracleManager
 from .stats_manager import StatsManager
 from .reporting_manager import ReportingManager
 from prescient.stats.overall_stats import OverallStats
+import prescient.plugins 
 
 from prescient.engine.egret import EgretEngine
 

--- a/prescient/simulator/simulator.py
+++ b/prescient/simulator/simulator.py
@@ -18,8 +18,7 @@ from prescient.engine.modeling_engine import ModelingEngine
 from .oracle_manager import OracleManager
 from .reporting_manager import ReportingManager
 from .stats_manager import StatsManager
-
-
+import prescient.plugins
 
 ## simulator class
 class Simulator:
@@ -61,6 +60,8 @@ class Simulator:
         self.stats_manager = stats_manager
         self.reporting_manager = reporting_manager
 
+        self.plugin_manager = prescient.plugins.get_active_plugin_manager()
+
 
     def simulate(self, options):
 
@@ -71,12 +72,16 @@ class Simulator:
         stats_manager = self.stats_manager
         reporting_manager = self.reporting_manager
 
+        self.plugin_manager.invoke_options_preview_callbacks(options)
+
         engine.initialize(options)
         time_manager.initialize(options)
         data_manager.initialize(engine, options)
         oracle_manager.initialize(engine, data_manager, options)
         stats_manager.initialize(options)
         reporting_manager.initialize(options, stats_manager)
+
+        self.plugin_manager.invoke_initialization_callbacks(options, self)
 
         first_time_step = time_manager.get_first_time_step()
 

--- a/prescient/stats/__init__.py
+++ b/prescient/stats/__init__.py
@@ -1,0 +1,3 @@
+from .daily_stats import DailyStats
+from .hourly_stats import HourlyStats
+from .overall_stats import OverallStats

--- a/prescient/stats/daily_stats.py
+++ b/prescient/stats/daily_stats.py
@@ -8,7 +8,7 @@
 #  ___________________________________________________________________________
 
 from dataclasses import dataclass, field
-from typing import TypeVar, Dict, Sequence, Tuple
+from typing import TypeVar, Dict, Sequence, Tuple, Any
 from datetime import date
 
 from prescient.stats.hourly_stats import HourlyStats
@@ -66,28 +66,6 @@ class DailyStats:
     this_date_quick_start_additional_power_generated: float = 0.0
     this_date_average_price: float #implemented as read-only property
 
-    ############### These are included in the hourly stats #####################
-    ## These are indexed by a model entity, mapping to an array of 24 hourly values
-    #observed_thermal_dispatch_levels: Dict[G, Sequence[float]]
-    #observed_thermal_headroom_levels: Dict[G, Sequence[float]]
-    #observed_renewables_levels: Dict[G, Sequence[float]]
-    #observed_renewables_curtailment: Dict[G, Sequence[float]]
-    #observed_thermal_states: Dict[G, Sequence[int]]
-    #observed_costs: Dict[G, Sequence[float]]
-    #observed_flow_levels: Dict[L, Sequence[float]]
-    #observed_bus_mismatches: Dict[B, Sequence[float]]
-    #observed_bus_LMPs: Dict[B, Sequence[float]]
-    #storage_input_dispatchlevelsdict: Dict[S, Sequence[float]]
-    #storage_output_dispatchlevelsdict: Dict[S, Sequence[float]]
-    #storage_soc_dispatchlevelsdict: Dict[S, Sequence[float]]
-
-    # This variable only has data if options.enable_quick_start_generator_commitment is True.
-    # It is indexed by generator, mapping to an array of hourly values (which are 0 or 1).
-    # The dictionary starts out with an entry per quick start generator, but the arrays
-    # start out empty and are appended to each hour.
-    ########### Commented out because this data is found in the hourly stats ##############
-    #used_as_quick_start: Dict[G, Sequence[float]] = field(default_factory=dict)
-
     # These variables are only populated if options.compute_market_settlements is True
     # They are indexed by a (model entity, hour) tuple, and start out empty.
     ######### They are commented out for now #######################
@@ -96,6 +74,8 @@ class DailyStats:
     #this_date_planning_thermal_generation_cleared: Dict[Tuple[G, int], float] = field(default_factory=dict)
     #this_date_planning_thermal_reserve_cleared: Dict[Tuple[G, int], float] = field(default_factory=dict)
     #this_date_planning_renewable_generation_cleared: Dict[Tuple[G, int], float] = field(default_factory=dict)
+
+    extensions: Dict[Any, Any]
 
     @property
     def this_date_total_costs(self):
@@ -109,50 +89,10 @@ class DailyStats:
     def this_date_renewables_penetration_rate(self):
         return (self.this_date_renewables_used / self.this_date_demand) * 100.0
 
-    #def __init__(self, options, ruc):
     def __init__(self, options, day: date):
         self.date = day
         self.hourly_stats = []
-
-        #self.observed_thermal_dispatch_levels = {g: np.repeat(0.0, 24)
-        #                                         for g in rc.ThermalGenerators}
-
-        #self.observed_thermal_headroom_levels = {g: np.repeat(0.0, 24)
-        #                                         for g in rc.ThermalGenerators}
-
-        #observed_renewables_levels = {g: np.repeat(0.0, 24)
-        #                              for g in rc.AllNondispatchableGenerators}
-
-        #observed_renewables_curtailment = {g: np.repeat(0.0, 24)
-        #                                   for g in rc.AllNondispatchableGenerators}
-
-        #observed_thermal_states = {g: np.repeat(-1, 24)
-        #                           for g in rc.ThermalGenerators}
-
-        #observed_costs = {g: np.repeat(0.0, 24)
-        #                  for g in rc.ThermalGenerators}
-
-        #observed_flow_levels = {l: np.repeat(0.0, 24) 
-        #                        for l in ruc.TransmissionLines}
-
-        #observed_bus_mismatches = {b: np.repeat(0.0, 24) 
-        #                           for b in ruc.Buses}
-
-        #observed_bus_LMPs = {b: np.repeat(0.0, 24) 
-        #                     for b in ruc.Buses}
-
-        #storage_input_dispatchlevelsdict = {s: np.repeat(0.0, 24) 
-        #                                    for s in ruc.Storage}
-
-        #storage_output_dispatchlevelsdict = {s: np.repeat(0.0, 24) 
-        #                                     for s in ruc.Storage}
-
-        #storage_soc_dispatchlevelsdict = {s: np.repeat(0.0, 24) 
-        #                                  for s in ruc.Storage}
-
-        #if options.enable_quick_start_generator_commitment:
-        #    for g in ruc.QuickStartGenerators:
-        #        self.used_as_quick_start[g]=[]
+        self.extensions = {}
 
     def incorporate_hour_stats(self, hourly_stats: HourlyStats):
         self.thermal_fleet_capacity = hourly_stats.thermal_fleet_capacity

--- a/prescient/stats/hourly_stats.py
+++ b/prescient/stats/hourly_stats.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from typing import Dict, Sequence, TypeVar
+    from typing import Dict, Sequence, TypeVar, Any
     from prescient.engine.data_extractors import ScedDataExtractor
     from prescient.engine.abstract_types import OperationsModel, G, L, B, S
 
@@ -54,7 +54,7 @@ class HourlyStats:
 
     quick_start_additional_costs: float = 0.0
     quick_start_additional_power_generated: float = 0.0
-    used_as_quick_start: Dict[G, int]
+    used_as_quickstart: Dict[G, int]
 
     event_annotations: Sequence[str]
 
@@ -79,7 +79,8 @@ class HourlyStats:
 
     #if options.compute_market_settlements:
     #    planning_reserve_price: float = 0.0
-    
+
+    extensions: Dict[Any, Any]
 
     @property
     def total_costs(self):
@@ -91,6 +92,7 @@ class HourlyStats:
         self.date = day
         self.hour = hour
         self.event_annotations = []
+        self.extensions = {}
 
     def populate_from_sced(self, 
                            sced: OperationsModel, 

--- a/prescient/stats/overall_stats.py
+++ b/prescient/stats/overall_stats.py
@@ -7,7 +7,7 @@
 #  This software is distributed under the Revised BSD License.
 #  ___________________________________________________________________________
 
-from typing import Sequence
+from typing import Sequence, Dict, Any
 from dataclasses import dataclass, field
 
 from prescient.stats.daily_stats import DailyStats
@@ -53,26 +53,7 @@ class OverallStats(object):
     #    total_payments = 0.0
     #    cumulative_average_payments: float # implemented as read-only property
 
-
-
-    ########## Commented out, including in daily stats ###################
-    ## These are arrays of daily values, with one value per day appended (arrays start out empty)
-    #daily_total_costs: Sequence[float] = field(default_factory=list)
-    #daily_fixed_costs: Sequence[float] = field(default_factory=list)
-    #daily_generation_costs: Sequence[float] = field(default_factory=list)
-    #daily_load_shedding: Sequence[float] = field(default_factory=list)
-    #daily_over_generation: Sequence[float] = field(default_factory=list)
-    #daily_reserve_shortfall: Sequence[float] = field(default_factory=list)
-    #daily_renewables_available: Sequence[float] = field(default_factory=list)
-    #daily_renewables_used: Sequence[float] = field(default_factory=list)
-    #daily_renewables_curtailment: Sequence[float] = field(default_factory=list)
-    #daily_on_offs: Sequence[float] = field(default_factory=list)
-    #daily_sum_on_off_ramps: Sequence[float] = field(default_factory=list)
-    #daily_sum_nominal_ramps: Sequence[float] = field(default_factory=list)
-    #daily_quick_start_additional_costs: Sequence[float] = field(default_factory=list)
-    #daily_quick_start_additional_power_generated: Sequence[float] = field(default_factory=list)
-    #daily_average_price: Sequence[float] = field(default_factory=list)
-    #daily_demand: Sequence[float] = field(default_factory=list)
+    extensions: Dict[Any, Any]
 
     @property
     def total_overall_costs(self):
@@ -96,6 +77,7 @@ class OverallStats(object):
 
     def __init__(self, options):
         self.daily_stats = []
+        self.extensions = {}
 
     def incorporate_day_stats(self, day_stats: DailyStats):
         self.daily_stats.append(day_stats)


### PR DESCRIPTION
This pull request demonstrates how we might provide plugin support for Prescient.  Here are the major elements of the approach:

- Support for the "--plugin=<module>" command line option
- A bunch of functions in prescient.plugins.plugin_registration.py.  Plugins call these methods to indicate how/when they want to be involved in a prescient run.  There is one registration function for each spot in the prescient process that a plugin might want to inject itself.  As one example, the `register_before_ruc_activation_callback` method lets a plugin do something each time a new RUC becomes active.
- Internally, there is a plugin manager class that stores all the registered callbacks and lets other prescient code call them.  Plugins never interact with the plugin manager directly, it just enables other code to trigger callbacks appropriately.

So far, the following callbacks have been fully implemented:
- Adding new command line options
- Viewing (and potentially changing) the results of parsing the command line
- Initialization, right after prescient has configured itself.
- Subscribing to stats at hourly, daily, and overall intervals

In addition to feedback on the general approach, I'd also like feedback on the proposed set of plugin callback points.  The file plugin_registration.py has a whole slew of `register_*_callback` functions that haven't yet been implemented (the signature is there, but all they do is `pass`), one for each hook point.  We should decide whether this is the right set of callbacks.  We also need to identify the right set of arguments to pass to the callback.  The simplest starting point is to pass the Simulator object, which gives the callback access to the DataManager, the StatsManager, and so on.  In most cases we'll want to send additional data, like the projected sched, the time and date, etc.