### PR TITLE
Performance enhancements for SCED

### DIFF
--- a/prescient/engine/egret/egret_plugin.py
+++ b/prescient/engine/egret/egret_plugin.py
@@ -32,7 +32,7 @@ uc_abstract_data_model = get_uc_model()
 # specified simulation hour.                                                           #
 ########################################################################################
 
-def call_solver(solver,instance,options,solver_options,relaxed=False):
+def call_solver(solver,instance,options,solver_options,relaxed=False, set_instance=True):
     tee = options.output_solver_logs
     if not tee:
         egret_logger.setLevel(logging.WARNING)
@@ -52,7 +52,7 @@ def call_solver(solver,instance,options,solver_options,relaxed=False):
 
     m, results, solver = _solve_unit_commitment(instance, solver, mipgap, None,
                                                 tee, symbolic_solver_labels, 
-                                                solver_options_dict, None, relaxed) 
+                                                solver_options_dict, None, relaxed, set_instance=set_instance)
 
     md = _save_uc_results(m, relaxed)
 
@@ -61,7 +61,7 @@ def call_solver(solver,instance,options,solver_options,relaxed=False):
     else:
         time = results.solver.wallclock_time
 
-    return md,time
+    return md, time, solver
 
 
 ## utility for constructing pyomo data dictionary from the passed in parameters to use
@@ -665,7 +665,7 @@ def _solve_deterministic_ruc(deterministic_ruc_instance,
     ptdf_manager.PTDF_matrix_dict = pyo_model._PTDFs
 
     try:
-        ruc_results, pyo_results = call_solver(solver,
+        ruc_results, pyo_results, _  = call_solver(solver,
                                             pyo_model, 
                                             options,
                                             options.deterministic_ruc_solver_options)
@@ -1220,7 +1220,7 @@ def solve_deterministic_day_ahead_pricing_problem(solver, ruc_results, options, 
 
     try:
         ## TODO: Should there be separate options for this run?
-        pricing_results, _ = call_solver(solver,
+        pricing_results, _, _ = call_solver(solver,
                                          pyo_model, 
                                          options,
                                          options.deterministic_ruc_solver_options,

--- a/prescient/engine/egret/egret_plugin.py
+++ b/prescient/engine/egret/egret_plugin.py
@@ -666,9 +666,9 @@ def _solve_deterministic_ruc(deterministic_ruc_instance,
 
     try:
         ruc_results, pyo_results, _  = call_solver(solver,
-                                            pyo_model, 
-                                            options,
-                                            options.deterministic_ruc_solver_options)
+                                                   pyo_model,
+                                                   options,
+                                                   options.deterministic_ruc_solver_options)
     except:
         print("Failed to solve deterministic RUC instance - likely because no feasible solution exists!")        
         output_filename = "bad_ruc.json"
@@ -1221,10 +1221,10 @@ def solve_deterministic_day_ahead_pricing_problem(solver, ruc_results, options, 
     try:
         ## TODO: Should there be separate options for this run?
         pricing_results, _, _ = call_solver(solver,
-                                         pyo_model, 
-                                         options,
-                                         options.deterministic_ruc_solver_options,
-                                         relaxed=True)
+                                            pyo_model,
+                                            options,
+                                            options.deterministic_ruc_solver_options,
+                                            relaxed=True)
     except:
         print("Failed to solve pricing instance - likely because no feasible solution exists!")        
         output_filename = "bad_pricing.json"

--- a/prescient/simulator/master_options.py
+++ b/prescient/simulator/master_options.py
@@ -598,7 +598,7 @@ def _construct_inner_options_parser():
                                         action='store',
                                         type='float',
                                         dest='price_threshold',
-                                        default=sys.float_info.max)
+                                        default=10000.)
     guiOverride['--price-threshold'] = {}
     guiOverride['--price-threshold']['bpa'] = False
 
@@ -609,7 +609,7 @@ def _construct_inner_options_parser():
                                         action='store',
                                         type='float',
                                         dest='reserve_price_threshold',
-                                        default=sys.float_info.max)
+                                        default=1000.)
     guiOverride['--reserve-price-threshold'] = {}
     guiOverride['--reserve-price-threshold']['bpa'] = False
                              

--- a/prescient/simulator/oracle_manager.py
+++ b/prescient/simulator/oracle_manager.py
@@ -323,17 +323,17 @@ class OracleManager(_Manager):
                 print("Re-solving SCED after unfixing Quick Start Generators")
                 current_sced_instance = self.engine.enable_quickstart_and_solve(current_sced_instance, options)
 
-        self.simulator.plugin_manager.invoke_after_operations_callbacks(options, self.simulator, current_sced_instance)
-
-
         print("Solving for LMPs")
         lmp_sced = self.engine.create_and_solve_lmp(current_sced_instance, options)
+
+        self.simulator.plugin_manager.invoke_after_operations_callbacks(options, self.simulator, current_sced_instance)
 
         ops_stats = self.simulator.stats_manager.collect_operations(current_sced_instance,
                                                                     solve_time,
                                                                     lmp_sced,
                                                                     pre_quickstart_cache,
                                                                     self.engine.operations_data_extractor)
+
         self.simulator.plugin_manager.invoke_update_operations_stats_callbacks(options, self.simulator, ops_stats)
         self._report_sced_stats(ops_stats)
 


### PR DESCRIPTION
Major changes:
1. Using a more compact SCED model from EGRET, utilizing https://github.com/grid-parity-exchange/Egret/pull/143
1. Enabling persistence from SCED to LMP SCED; recycling pyomo model when a non-persistent solver is used (progress towards #31)

Other changes:
1. Changing after_operations_callbacks to be invoked after LMP SCED to maintain consistency between SCED and LMP SCED.
1. Using persistent solvers by default (closes #40)
1. Setting defaults for threshold values to those already in EGRET