### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ Code base for Prescient production cost model / scenario generation / prediction
 
 ### Requirements
 * Python 3.7 or later
+* Pyomo 5.6 or later (Xpress users, 5.7.1 or later)
+* EGRET
 * A mixed-integer linear programming (MILP) solver
   * Open source: CBC, GLPK, SCIP, ...
-  * Commercial: Gurobi, CPLEX, ...
+  * Commercial: CPLEX, Gurobi, Xpress, ...
 
 ### Installation
-1. Clone or download/extract the Prescient repository.
-2. The root of the repository will contain a `setup.py` file. In the command prompt or terminal, change your working directory to the root of the repository. Execute the following command:
+1. Install EGRET according to the instructions [here](https://github.com/grid-parity-exchange/Egret/blob/master/README.md).
+2. Clone or download/extract the Prescient repository.
+3. The root of the repository will contain a `setup.py` file. In the command prompt or terminal, change your working directory to the root of the repository. Execute the following command:
 ```
 python setup.py develop
 ```
@@ -26,14 +29,45 @@ Usage: runner.py config_file
 
 The installation of Prescient has added the `runner.py` command which is used to execute Prescient programs from the command line.
 
-#### Solvers
-We additionally recommend that users install the open source CBC MIP solver. The specific mechanics of installing CBC are platform-specific. When using Anaconda on Linux and Mac platforms, this can be accomplished simply by:
+### Solvers
+If not using one of the commerical solvers describe below, we recommend users install the open source CBC MIP solver. The specific mechanics of installing CBC are platform-specific. When using Anaconda on Linux and Mac platforms, this can be accomplished simply by:
 
 ```
 conda install -c conda-forge coincbc
 ```
 
-The COIN-OR organization - who developers CBC - also provides pre-built binaries for a full range of platforms on https://bintray.com/coin-or/download.
+The COIN-OR organization - who developers CBC - also provides pre-built binaries for a full range of platforms (including Windows) on https://bintray.com/coin-or/download.
+
+
+#### Using a commercial solver
+If you have a license for a commericial MILP solver (CPLEX, Gurobi, or Xpress), it is recommended over CBC. Further, it is best to have the Python bindings installed for said solver. 
+
+##### CPLEX
+Instructions for installing Python bindings for CPLEX can be found [here](https://www.ibm.com/support/knowledgecenter/en/SSSA5P_12.8.0/ilog.odms.cplex.help/CPLEX/GettingStarted/topics/set_up/Python_setup.html).
+
+
+##### Gurobi
+Python binding for Gurobi can be installed via conda:
+```
+conda install -c gurobi gurobi
+```
+Depending on your license, you may not be able to use the latest version of the solver.
+A specific release can be installed as follows:
+```
+conda install -c gurobi gurobi=8
+```
+
+##### Xpress
+Xpress Python bindings are both available through PyPI, e.g.:
+```
+pip install xpress
+```
+Depending on your license, you may need to install a specific version of the solver, e.g.,
+```
+pip install xpress==8.8.6
+```
+Note for Xpress users: using the Python bindings for Xpress requires at least Pyomo 5.7.1.
+
 
 ### Testing Prescient
 Prescient is packaged with some utility to test and demonstrate its functionality. Here we will walk through the simulation of an [RTS-GMLC](https://github.com/GridMod/RTS-GMLC) case.
@@ -78,29 +112,35 @@ Note: This is assuming that you have installed the solver CBC as recommended. If
 --sced-solver=cbc
 ```
 
+For example, if you were using Xpress, these lines would be changed to:
+```
+--deterministic-ruc-solver=xpress
+--sced-solver=xpress
+```
+and similarily for Gurobi (`gurobi`) and CPLEX (`cplex`).
+
 You can watch the progress of the simulator as it is printed to the console. After a period of time, the simulation will be complete. The results will be found a in a new folder `deterministic_with_network_simulation_output`. In that directory, there will be a number of .csv files containing simulation results. An additional folder `plots` contains stack graphs for each day in the simulation, summarizing generation and demand at each time step.
 
 ### (For developers) Regression tests
-A unit test for testing a populator and simulator run on the RTS-GMLC data is located [here](https://github.com/jwatsonnm/prescient/blob/master/tests/simulator_tests/test_pop_sim_rts-gmlc.py):
+A unit test for testing a simulator run on the based on a single-zone of the RTS-GMLC data is located [here](https://github.com/grid-parity-exchange/prescient/blob/master/tests/simulator_tests/test_sim_rts_mod.py):
 
 ```
-tests/simulator_tests/test_pop_sim_rts-gmlc.py
+tests/simulator_tests/test_sim_rts_mod.py
 ```
-
-It downloads the RTS-GMLC data, runs the populator and simulator for one week, and compares simulation output to static results (saved in the repo) and uses a diff check with tolerances to evaluate the test. It’s designed to be ran in a fresh instance via Travis CI so you need not provide any data or parameters. 
+It runs two one-week simulations, and compares simulation output to static results (saved in the repo) and uses a diff check with tolerances to evaluate the test. It’s designed to be ran in a fresh instance via GitHub Actions so you need not provide any data or parameters.
 
 The definitions of numeric fields are in numeric_fields.json; these define the fields in each output csv file with which to do results comparisons. The difference tolerances of those fields are similarly defined in tolerances.json but have default values if not explicitly defined.
 
 You can run the script directly:
 
 ```
-python test_pop_sim_rts-gmlc.py
+python test_sim_rts_mod.py
 ```
 
 or use the Python unit test interface:
 
 ```
-python -m unittest test_pop_sim_rts-gmlc.py
+python -m unittest test_sim_rts_mod.py
 ```
 
 ### Developers


### PR DESCRIPTION
The README is currently out-of-date. Changes:
1. Direct users to install EGRET
1. Basic instructions for setting up and using commercial solvers
1. Pointing to the currently-used tests.