### PR TITLE
Update requirements to pyomo>=5.7

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -13,6 +13,6 @@ dependencies:
 - ply
 - python-dateutil
 - pytz
-- pyomo
+- pyomo>=5.7
 - scipy
 - six

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='prescient',
             ]
         },
       package_data={'prescient.downloaders.rts_gmlc_prescient':['runners/*.txt','runners/templates/*']},
-      install_requires=['numpy','matplotlib','pandas','scipy','pyomo','six',
+      install_requires=['numpy','matplotlib','pandas','scipy','pyomo>=5.7','six',
                         'pyutilib', 'python-dateutil', 'networkx',
                         'egret @ git+https://github.com/grid-parity-exchange/Egret.git'],
       dependency_links=['git+https://github.com/grid-parity-exchange/Egret.git#egg=egret'],


### PR DESCRIPTION
This PR would make pyomo>=5.7 a requirement for Prescient. This is necessary due to upstream changes in EGRET and Pyomo (see https://github.com/grid-parity-exchange/Egret/pull/158).