### PR TITLE
Minor additions / tweaks to Prescient output files

### DIFF
--- a/prescient/engine/data_extractors.py
+++ b/prescient/engine/data_extractors.py
@@ -101,6 +101,11 @@ class ScedDataExtractor(ABC):
         pass
 
     @abstractmethod
+    def get_bus_demand(self, sced: OperationsModel, bus: B) -> float:
+        """Get the demand at a specific bus."""
+        pass    
+
+    @abstractmethod
     def get_bus_mismatch(self, sced: OperationsModel, bus: B) -> float:
         """Get the absolute value of the bus's load mismatch."""
         pass
@@ -363,6 +368,10 @@ class ScedDataExtractor(ABC):
     def get_all_flow_levels(self, sced: OperationsModel) -> Dict[L, float]:
         return {l: self.get_flow_level(sced, l)
                 for l in self.get_transmission_lines(sced)}
+
+    def get_all_bus_demands(self, sced: OperationsModel) -> Dict[B, float]:
+        return {b: self.get_bus_demand(sced, b)
+                for b in self.get_buses(sced)}
 
     def get_all_bus_mismatches(self, sced: OperationsModel) -> Dict[B, float]: 
         return {b: self.get_bus_mismatch(sced, b)

--- a/prescient/simulator/reporting_manager.py
+++ b/prescient/simulator/reporting_manager.py
@@ -119,6 +119,7 @@ class ReportingManager(_Manager):
         bus_columns = {'Date':       lambda hourly,b: str(hourly.date),
                        'Hour':       lambda hourly,b: hourly.hour + 1,
                        'Bus':        lambda hourly,b: b,
+                       'Demand':     lambda hourly,b: hourly.bus_demands[b],                       
                        'Shortfall':     lambda hourly,b: hourly.observed_bus_mismatches[b] if hourly.observed_bus_mismatches[b] > 0.0 else 0.0,
                        'Overgeneration':  lambda hourly,b: -hourly.observed_bus_mismatches[b] if hourly.observed_bus_mismatches[b] < 0.0 else 0.0,
                        'LMP':   lambda hourly,b: hourly.observed_bus_LMPs[b],

--- a/prescient/simulator/reporting_manager.py
+++ b/prescient/simulator/reporting_manager.py
@@ -143,7 +143,7 @@ class ReportingManager(_Manager):
         stats_manager.register_for_overall_stats(lambda overall: line_file.close())
 
     def setup_hourly_gen_summary(self, options, stats_manager: StatsManager):
-        hourly_gen_path = os.path.join(options.output_directory, 'Hourly_gen_summary.csv')
+        hourly_gen_path = os.path.join(options.output_directory, 'hourly_gen_summary.csv')
         hourly_gen_file = open(hourly_gen_path, 'w', newline='')
         hourly_gen_columns = {'Date': lambda hourly: str(hourly.date),
                               'Hour': lambda hourly: hourly.hour + 1,
@@ -180,7 +180,7 @@ class ReportingManager(_Manager):
 
 
     def setup_daily_summary(self, options, stats_manager: StatsManager):
-        daily_path = os.path.join(options.output_directory, 'Daily_summary.csv')
+        daily_path = os.path.join(options.output_directory, 'daily_summary.csv')
         daily_file = open(daily_path, 'w', newline='')
         daily_columns = {'Date': lambda daily: str(daily.date),
                          'Demand': lambda daily: daily.this_date_demand,
@@ -216,7 +216,7 @@ class ReportingManager(_Manager):
         # We implement this as an inner function so that we can open and close the file
         # at the end of the simulation instead of keeping it open the whole session
         def write_overall_stats(overall: OverallStats):
-            overall_path = os.path.join(options.output_directory, 'Overall_simulation_output.csv')
+            overall_path = os.path.join(options.output_directory, 'overall_simulation_output.csv')
             overall_file = open(overall_path, 'w', newline='')
             overall_cols = {'Total demand':            lambda overall: overall.cumulative_demand,
                             'Total fixed costs':       lambda overall: overall.total_overall_fixed_costs,

--- a/prescient/stats/hourly_stats.py
+++ b/prescient/stats/hourly_stats.py
@@ -67,6 +67,8 @@ class HourlyStats:
 
     observed_flow_levels: Dict[L, float]
 
+    bus_demands: Dict[B, float]
+
     observed_bus_mismatches: Dict[B, float]
     observed_bus_LMPs: Dict[B, float]
 
@@ -190,6 +192,8 @@ class HourlyStats:
         self.observed_renewables_curtailment = extractor.get_all_renewables_curtailment(sced)
 
         self.observed_flow_levels = extractor.get_all_flow_levels(sced)
+
+        self.bus_demands = extractor.get_all_bus_demands(sced)        
 
         self.observed_bus_mismatches = extractor.get_all_bus_mismatches(sced)
         self.observed_bus_LMPs = extractor.get_all_bus_LMPs(lmp_sced)


### PR DESCRIPTION
Per a need for an LLNL project, added bus demand to bus_detail.csv - which makes it consistent with renewables_available being propagated through to renewables_detail.csv. Makes for easier scripting for analysis. Also changed summary output file case convention, to make everything consistent. 