### PR TITLE
Add missing import

### DIFF
--- a/prescient/scripts/simulator.py
+++ b/prescient/scripts/simulator.py
@@ -13,4 +13,5 @@ def main(args=None):
     prescient.simulator.prescient.main(args)
 
 if __name__ == '__main__':
+    import sys
     main(sys.argv)


### PR DESCRIPTION
The simulator script can't be run at the command line because of a missing import statement.