### PR TITLE
Update requirements to Pyomo 5.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Code base for Prescient production cost model / scenario generation / prediction
 
 ### Requirements
 * Python 3.7 or later
-* Pyomo 5.7 or later (Xpress users, 5.7.1 or later)
+* Pyomo 5.7.1 or later
 * EGRET
 * A mixed-integer linear programming (MILP) solver
   * Open source: CBC, GLPK, SCIP, ...

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - ply
 - python-dateutil
 - pytz
-- pyomo>=5.7
+- pyomo>=5.7.1
 - scipy
 - six
 - ipopt

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='prescient',
             ]
         },
       package_data={'prescient.downloaders.rts_gmlc_prescient':['runners/*.txt','runners/templates/*']},
-      install_requires=['numpy','matplotlib','pandas','scipy','pyomo>=5.7','six',
+      install_requires=['numpy','matplotlib','pandas','scipy','pyomo>=5.7.1','six',
                         'pyutilib', 'python-dateutil', 'networkx',
                         'egret @ git+https://github.com/grid-parity-exchange/Egret.git'],
       dependency_links=['git+https://github.com/grid-parity-exchange/Egret.git#egg=egret'],


### PR DESCRIPTION
With https://github.com/grid-parity-exchange/Egret/pull/179, we now have a soft requirement of Pyomo 5.7.1. This PR would make this a strict requirement for Prescient. 