### PR TITLE
Startup/Shutdown Curves

### DIFF
--- a/prescient/data/simulation_state/_helper.py
+++ b/prescient/data/simulation_state/_helper.py
@@ -74,13 +74,14 @@ def get_generator_states_at_sced_offset(original_state:SimulationState,
             max_power_output = g_dict['p_max']
                 
         # TBD: Eventually make the 1e-5 an user-settable option.
-        #if unit_on == 0:
-        #    # if the unit is off, then the power generated at t0 must be equal to 0
-        #    power_generated = 0.0
-        #elif math.isclose(min_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
-        #    power_generated = min_power_output
-        #elif math.isclose(max_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
-        #    power_generated = max_power_output
+        if unit_on == 0:
+            # if the unit is off, then the power generated at 
+            # t0 must be greater than or equal to 0 (Egret #219)
+            power_generated = max(power_generated, 0.0)
+        elif math.isclose(min_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
+            power_generated = min_power_output
+        elif math.isclose(max_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
+            power_generated = max_power_output
 
         ### Yield the results for this generator ###
         yield GeneratorState(g,state_duration, power_generated)

--- a/prescient/data/simulation_state/_helper.py
+++ b/prescient/data/simulation_state/_helper.py
@@ -74,13 +74,13 @@ def get_generator_states_at_sced_offset(original_state:SimulationState,
             max_power_output = g_dict['p_max']
                 
         # TBD: Eventually make the 1e-5 an user-settable option.
-        if unit_on == 0:
-            # if the unit is off, then the power generated at t0 must be equal to 0
-            power_generated = 0.0
-        elif math.isclose(min_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
-            power_generated = min_power_output
-        elif math.isclose(max_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
-            power_generated = max_power_output
+        #if unit_on == 0:
+        #    # if the unit is off, then the power generated at t0 must be equal to 0
+        #    power_generated = 0.0
+        #elif math.isclose(min_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
+        #    power_generated = min_power_output
+        #elif math.isclose(max_power_output, power_generated, rel_tol=0, abs_tol=1e-5):
+        #    power_generated = max_power_output
 
         ### Yield the results for this generator ###
         yield GeneratorState(g,state_duration, power_generated)

--- a/prescient/engine/egret/egret_plugin.py
+++ b/prescient/engine/egret/egret_plugin.py
@@ -173,7 +173,6 @@ def create_sced_instance(data_provider:DataProvider,
     assert options.relax_t0_ramping_initial_day is False
 
     # Set generator commitments & future state
-    #print(f"current_state.timestep_count: {current_state.timestep_count}")
     for g, g_dict in sced_md.elements(element_type='generator', generator_type='thermal'):
         # Start by preparing an empty array of the correct size for each generator
         fixed_commitment = [None]*sced_horizon
@@ -198,7 +197,6 @@ def create_sced_instance(data_provider:DataProvider,
         else: # no break
             future_status_time_steps = 0
         g_dict['future_status'] = (current_state.minutes_per_step/60.) * future_status_time_steps
-        #print(f"g: {g}, future_status: {g_dict['future_status']}")
 
     if not options.no_startup_shutdown_curves:
         for g, g_dict in sced_md.elements(element_type='generator', generator_type='thermal'):
@@ -217,7 +215,6 @@ def create_sced_instance(data_provider:DataProvider,
 
             g_dict['startup_curve'] = [ sced_startup_capacity - i*ramp_up_rate_sced \
                                         for i in range(1,int(math.ceil(sced_startup_capacity/ramp_up_rate_sced))) ]
-            #print(f"{g} : p_min: {g_dict['p_min']}, startup_curve: {g_dict['startup_curve']}")
 
         for g, g_dict in sced_md.elements(element_type='generator', generator_type='thermal'):
             if 'shutdown_curve' in g_dict:
@@ -247,12 +244,10 @@ def create_sced_instance(data_provider:DataProvider,
 
                 g_dict['shutdown_curve'] = [ sced_shutdown_capacity - i*ramp_down_rate_sced \
                                              for i in range(1,int(math.ceil(sced_shutdown_capacity/ramp_down_rate_sced))) ]
-                #print(f"{g} : p_min: {g_dict['p_min']}, shutdown_curve: {g_dict['shutdown_curve']}")
             else:
                 ## infer the shutdown curve from the output status
                 g_dict['shutdown_curve'] = [ power_t0 + i*ramp_down_rate_sced for i in range(time_periods_off-1,-1,-1) ] + \
                                            [ power_t0 - i*ramp_down_rate_sced for i in range(1,int(math.ceil(power_t0/ramp_down_rate_sced))) ]
-                #print(f"{g} : initial_status: {initial_status}, initial_p_output: {power_t0}, shutdown_curve: {g_dict['shutdown_curve']}")
 
 
     if not options.enforce_sced_shutdown_ramprate:

--- a/prescient/engine/egret/egret_plugin.py
+++ b/prescient/engine/egret/egret_plugin.py
@@ -182,6 +182,11 @@ def create_sced_instance(data_provider:DataProvider,
         for t in range(sced_horizon):
             fixed_commitment[t] = current_state.get_generator_commitment(g,t)
 
+    if not options.enforce_sced_shutdown_ramprate:
+        for g, g_dict in sced_md.elements(element_type='generator', generator_type='thermal'):
+            # make sure the generator can immediately turn off
+            g_dict['shutdown_capacity'] = max(g_dict['shutdown_capacity'], (60./options.sced_frequency_minutes)*g_dict['initial_p_output'] + 1.)
+
     return sced_md
 
 

--- a/prescient/engine/egret/egret_plugin.py
+++ b/prescient/engine/egret/egret_plugin.py
@@ -125,9 +125,9 @@ def create_sced_instance(data_provider:DataProvider,
                          sced_horizon,
                          forecast_error_method = ForecastErrorMethod.PRESCIENT
                          ):
-    ''' Create an hourly deterministic economic dispatch instance, given current forecasts and commitments.
+    ''' Create a deterministic economic dispatch instance, given current forecasts and commitments.
     '''
-    assert current_state != None
+    assert current_state is not None
 
     sced_md = data_provider.get_initial_model(options, sced_horizon, current_state.minutes_per_step)
 
@@ -199,19 +199,17 @@ def create_sced_instance(data_provider:DataProvider,
         g_dict['future_status'] = (current_state.minutes_per_step/60.) * future_status_time_steps
 
     if not options.no_startup_shutdown_curves:
+        minutes_per_step = current_state.minutes_per_step
         for g, g_dict in sced_md.elements(element_type='generator', generator_type='thermal'):
             if 'startup_curve' in g_dict:
                 continue
-            ramp_up_rate_sced = g_dict['ramp_up_60min'] * (current_state.minutes_per_step)/60.
+            ramp_up_rate_sced = g_dict['ramp_up_60min'] * minutes_per_step/60.
             if 'startup_capacity' not in g_dict:
-                if isinstance(g_dict['p_min'], dict):
-                    sced_startup_capacity = [p_min+ramp_up_rate_sced/2. for p_min in g_dict['p_min']['values']]
-                    sced_startup_capacity = sum(sced_startup_capacity)/len(sced_startup_capacity)
-                else:
-                    sced_startup_capacity = g_dict['p_min'] + ramp_up_rate_sced/2.
+                sced_startup_capacity = _calculate_sced_startup_shutdown_capacity_from_none(
+                                            g_dict['p_min'], ramp_up_rate_sced)
             else:
-                # TODO: generalize to time-varying pmin/shutdown capacity
-                sced_startup_capacity = (g_dict['startup_capacity'] - g_dict['p_min'])*(current_state.minutes_per_step/60.) + g_dict['p_min']
+                sced_startup_capacity = _calculate_sced_startup_shutdown_capacity_from_existing(
+                                            g_dict['startup_capacity'], g_dict['p_min'], minutes_per_step)
 
             g_dict['startup_curve'] = [ sced_startup_capacity - i*ramp_up_rate_sced \
                                         for i in range(1,int(math.ceil(sced_startup_capacity/ramp_up_rate_sced))) ]
@@ -219,36 +217,30 @@ def create_sced_instance(data_provider:DataProvider,
         for g, g_dict in sced_md.elements(element_type='generator', generator_type='thermal'):
             if 'shutdown_curve' in g_dict:
                 continue
-            ramp_down_rate_sced = g_dict['ramp_down_60min'] * (current_state.minutes_per_step)/60.
-            power_t0 = g_dict['initial_p_output']
-            initial_status = g_dict['initial_status']
-            if initial_status > 0.:
-                time_periods_off = 0
+
+            ramp_down_rate_sced = g_dict['ramp_down_60min'] * minutes_per_step/60.
+            # compute a new shutdown curve if we go from "on" to "off"
+            if g_dict['initial_status'] > 0 and g_dict['fixed_commitment']['values'][0] == 0:
+                power_t0 = g_dict['initial_p_output']
+                # if we end up using a historical curve, it's important
+                # for the time-horizons to match, particularly since this
+                # function is also used to create long-horizon look-ahead
+                # SCEDs for the unit commitment process
+                create_sced_instance.shutdown_curves[g, minutes_per_step] = \
+                        [ power_t0 - i*ramp_down_rate_sced for i in range(1,int(math.ceil(power_t0/ramp_down_rate_sced))) ]
+
+            if (g,minutes_per_step) in create_sced_instance.shutdown_curves:
+                g_dict['shutdown_curve'] = create_sced_instance.shutdown_curves[g,minutes_per_step]
             else:
-                time_periods_off = int(math.ceil(-initial_status*60./current_state.minutes_per_step))
-            if options.enforce_sced_shutdown_ramprate or \
-                    (power_t0 <= 0.) or \
-                    ((power_t0 + (time_periods_off-1)*ramp_down_rate_sced) > g_dict['p_max']):
-                # in the first case, the generator will shut-down around the shut-down power
-                # in the second case, the generator is *definitely not* in shut-down process
-                # in the third case, the generator is *definitely* in the *start-up* process
                 if 'shutdown_capacity' not in g_dict:
-                    if isinstance(g_dict['p_min'], dict):
-                        sced_shutdown_capacity = [p_min+ramp_down_rate_sced/2. for p_min in g_dict['p_min']['values']]
-                        sced_startup_capacity = sum(sced_startup_capacity)/len(sced_startup_capacity)
-                    else:
-                        sced_shutdown_capacity = g_dict['p_min'] + ramp_down_rate_sced/2.
+                    sced_shutdown_capacity = _calculate_sced_startup_shutdown_capacity_from_none(
+                                                g_dict['p_min'], ramp_down_rate_sced)
                 else:
-                    # TODO: generalize to time-varying pmin/shutdown capacity
-                    sced_shutdown_capacity = (g_dict['shutdown_capacity'] - g_dict['p_min'])*(current_state.minutes_per_step/60.) + g_dict['p_min']
+                    sced_shutdown_capacity = _calculate_sced_startup_shutdown_capacity_from_existing(
+                                                g_dict['shutdown_capacity'], g_dict['p_min'], minutes_per_step)
 
                 g_dict['shutdown_curve'] = [ sced_shutdown_capacity - i*ramp_down_rate_sced \
                                              for i in range(1,int(math.ceil(sced_shutdown_capacity/ramp_down_rate_sced))) ]
-            else:
-                ## infer the shutdown curve from the output status
-                g_dict['shutdown_curve'] = [ power_t0 + i*ramp_down_rate_sced for i in range(time_periods_off-1,-1,-1) ] + \
-                                           [ power_t0 - i*ramp_down_rate_sced for i in range(1,int(math.ceil(power_t0/ramp_down_rate_sced))) ]
-
 
     if not options.enforce_sced_shutdown_ramprate:
         for g, g_dict in sced_md.elements(element_type='generator', generator_type='thermal'):
@@ -256,6 +248,34 @@ def create_sced_instance(data_provider:DataProvider,
             g_dict['shutdown_capacity'] = max(g_dict['shutdown_capacity'], (60./current_state.minutes_per_step)*g_dict['initial_p_output'] + 1.)
 
     return sced_md
+
+# cache for shutdown curves
+create_sced_instance.shutdown_curves = dict()
+
+def _calculate_sced_startup_shutdown_capacity_from_none(p_min, ramp_rate_sced):
+    if isinstance(p_min, dict):
+        sced_susd_capacity = [pm+ramp_rate_sced/2. for pm in p_min['values']]
+        return sum(sced_susd_capacity)/len(sced_susd_capacity)
+    else:
+        return p_min + ramp_rate_sced/2.
+
+def _calculate_sced_startup_shutdown_capacity_from_existing(startup_shutdown, p_min, minutes_per_step):
+    susd_capacity_time_varying = isinstance(startup_shutdown, dict)
+    p_min_time_varying = isinstance(p_min, dict)
+    if p_min_time_varying and susd_capacity_time_varying:
+        sced_susd_capacity = [ (susd - pm)*(minutes_per_step/60.) + pm \
+                                    for pm, susd in zip(p_min['values'], startup_shutdown['values']) ]
+        return sum(sced_susd_capacity)/len(sced_susd_capacity)
+    elif p_min_time_varying:
+        sced_susd_capacity = [ (startup_shutdown - pm)*(minutes_per_step/60.) + pm \
+                                    for pm in p_min['values'] ]
+        return sum(sced_susd_capacity)/len(sced_susd_capacity)
+    elif susd_capacity_time_varying:
+        sced_susd_capacity = [ (susd - p_min)*(minutes_per_step/60.) + p_min \
+                                    for susd in startup_shutdown['values'] ]
+        return sum(sced_susd_capacity)/len(sced_susd_capacity)
+    else:
+        return (startup_shutdown - p_min)*(minutes_per_step/60.) + p_min
 
 
 ##### BEGIN Deterministic RUC solvers and helper functions ########

--- a/prescient/simulator/master_options.py
+++ b/prescient/simulator/master_options.py
@@ -554,8 +554,10 @@ def _construct_inner_options_parser():
                                         default=60)
 
     input_simulation_options.add_option("--enforce-sced-shutdown-ramprate",
-                                        help="Relaxes the shutdown ramp rate in the SCED, "
-                                             "allowing for short look-ahead problems to be use.",
+                                        help="Enforces shutdown ramp-rate constraints in the SCED. "
+                                             "Enabling this options requires a long SCED look-ahead "
+                                             "(at least an hour) to ensure the shutdown ramp-rate "
+                                             "constraints can be statisfied.",
                                         action="store_true",
                                         dest="enforce_sced_shutdown_ramprate",
                                         default=False)

--- a/prescient/simulator/master_options.py
+++ b/prescient/simulator/master_options.py
@@ -536,7 +536,7 @@ def _construct_inner_options_parser():
 
     input_simulation_options.add_option('--sced-horizon',
                                         help="Specifies the number of time periods "
-                                             "when each SCED process is executed. "
+                                             "in the look-ahead horizon for each SCED. "
                                              "Must be at least 1.",
                                         action='store',
                                         dest='sced_horizon',

--- a/prescient/simulator/master_options.py
+++ b/prescient/simulator/master_options.py
@@ -535,8 +535,9 @@ def _construct_inner_options_parser():
     guiOverride["--ruc-horizon"]['bpa'] = False
 
     input_simulation_options.add_option('--sced-horizon',
-                                        help="Specifies the number of look-ahead time periods "
-                                             "when each SCED process is executed.",
+                                        help="Specifies the number of time periods "
+                                             "when each SCED process is executed. "
+                                             "Must be at least 1.",
                                         action='store',
                                         dest='sced_horizon',
                                         type='int',

--- a/prescient/simulator/master_options.py
+++ b/prescient/simulator/master_options.py
@@ -535,12 +535,12 @@ def _construct_inner_options_parser():
     guiOverride["--ruc-horizon"]['bpa'] = False
 
     input_simulation_options.add_option('--sced-horizon',
-                                        help="Specifies the number of hours in the look-ahead horizon "
+                                        help="Specifies the number of look-ahead time periods "
                                              "when each SCED process is executed.",
                                         action='store',
                                         dest='sced_horizon',
                                         type='int',
-                                        default=24)
+                                        default=1)
     guiOverride['--sced-horizon'] = {}
     guiOverride['--sced-horizon']['bpa'] = False
 
@@ -551,6 +551,24 @@ def _construct_inner_options_parser():
                                         dest='sced_frequency_minutes',
                                         type='int',
                                         default=60)
+
+    input_simulation_options.add_option("--enforce-sced-shutdown-ramprate",
+                                        help="Relaxes the shutdown ramp rate in the SCED, "
+                                             "allowing for short look-ahead problems to be use.",
+                                        action="store_true",
+                                        dest="enforce_sced_shutdown_ramprate",
+                                        default=False)
+    guiOverride["--enforce-sced-shutdown-ramprate"] = {}
+    guiOverride["--enforce-sced-shutdown-ramprate"]["--enforce-sced-shutdown-ramprate"] = False
+
+    input_simulation_options.add_option("--no-startup-shutdown-curves",
+                                        help="For thermal generators, do not infer startup/shutdown "
+                                             "ramping curves when starting-up and shutting-down.",
+                                        action="store_true",
+                                        dest="no_startup_shutdown_curves",
+                                        default=False)
+    guiOverride["--no-startup-shutdown-curves"] = {}
+    guiOverride["--no-startup-shutdown-curves"]["--no-startup-shutdown-curves"] = False
 
     input_simulation_options.add_option("--random-seed",
                                         help="Seed the random number generator used in the simulation. "

--- a/prescient/simulator/oracle_manager.py
+++ b/prescient/simulator/oracle_manager.py
@@ -208,7 +208,7 @@ class OracleManager(_Manager):
         print("")
         print("Solving SCED instance")
 
-        sced_horizon_timesteps = options.sced_horizon * 60 // options.sced_frequency_minutes
+        sced_horizon_timesteps = options.sced_horizon
         current_sced_instance = self.engine.create_sced_instance(
             options,
             self.data_manager.current_state.get_state_with_step_length(options.sced_frequency_minutes),

--- a/tests/simulator_tests/test_cases/simulate_deterministic.txt
+++ b/tests/simulator_tests/test_cases/simulate_deterministic.txt
@@ -5,11 +5,15 @@ command/exec simulator.py
 --output-directory=deterministic_simulation_output
 --run-deterministic-ruc 
 --start-date=07-10-2020
---num-days=7 
+--num-days=7
 --sced-horizon=4
 --ruc-mipgap=0.00
 --reserve-factor=0.0 
 --deterministic-ruc-solver=cbc
 --deterministic-ruc-solver-options="feas=off DivingG=on"
 --sced-solver=cbc
+--sced-frequency-minutes=60
 --ruc-horizon=36
+--traceback
+--enforce-sced-shutdown-ramprate
+--no-startup-shutdown-curves

--- a/tests/simulator_tests/test_cases/simulate_with_network_deterministic.txt
+++ b/tests/simulator_tests/test_cases/simulate_with_network_deterministic.txt
@@ -11,5 +11,8 @@ command/exec simulator.py
 --reserve-factor=0.0 
 --deterministic-ruc-solver=cbc
 --deterministic-ruc-solver-options="feas=off DivingG=on"
+--sced-frequency-minutes=60
 --sced-solver=cbc
 --ruc-horizon=36
+--enforce-sced-shutdown-ramprate
+--no-startup-shutdown-curves


### PR DESCRIPTION
Enables the new startup/shutdown curves in Egret https://github.com/grid-parity-exchange/Egret/pull/219. This enables more-realistic 5-minute simulations by modeling power injected by generators that just turned off or are about to turn on. When turning off, the shutdown curve is calculated from the last time the generator was on and injecting power.

Additionally, Prescient can now be run with a single-period SCED, which is commonly done is practice and is more performant. New options to preserve the old capability are disabled *by default*:
- `--enforce-sced-shutdown-ramprate`: always enforces the ramp-down rate for the SCED. By disabling this by default, we ensure generators are always available to turn-off, which ensures a SCED problem does not run into shutdown-ramp infeasibilities.
- `--no-startup-shutdown-curves`: disables the startup/shutdown curve computation for the SCED.

This PR also changes the meaning of the option `--sced-horizon` to be the absolute number of time-steps in individual SCED problems, and changes the default to `1`. The original meaning did not allow for 5-minute interval SCEDs with a look-ahead shorter than one hour.

Closes #57.