### PR TITLE
Making directory if it does not exist in RTS-GMLC template writer

### DIFF
--- a/prescient/downloaders/rts_gmlc_prescient/rtsgmlc_to_dat.py
+++ b/prescient/downloaders/rts_gmlc_prescient/rtsgmlc_to_dat.py
@@ -13,6 +13,7 @@ import sys
 import os
 import pandas as pd
 import math
+import pathlib
 
 from collections import namedtuple
 
@@ -158,6 +159,9 @@ def write_template( rts_gmlc_dir, file_name, copper_sheet = False, reserve_facto
     minutes_per_time_period = 60
     ## we'll bring the ramping down by this factor
     ramp_scaling_factor = 1.
+
+    # make the directory for the file if it does not exist
+    pathlib.Path(file_name).parent.mkdir(parents=True, exist_ok=True)
     
     dat_file = open(file_name,"w")
     


### PR DESCRIPTION
As-is, users made come upon and error in the tutorial when calling `prescient.downloaders.rts_gmlc_prescient.rtsgmlc_to_dat.write_template` if the `template` directory did not exist.

It apparently used to be created as a side-effect of another function; this makes the function writing the template responsible for ensuring its creation. Thanks to @isatkaus for finding this particular bug.
