### PR TITLE
add after simulation callbacks

### DIFF
--- a/prescient/plugins/internal.py
+++ b/prescient/plugins/internal.py
@@ -15,7 +15,7 @@ pending_overall_subscribers = []
 
 class PluginCallbackManager():
     '''
-    Keeps track of what callback methods have been registered, and 
+    Keeps track of what callback methods have been registered, and
     provides methods to invoke callbacks at appropriate times.
     '''
     def __init__(self):
@@ -25,7 +25,8 @@ class PluginCallbackManager():
                      'after_ruc_activation',
                      'before_operations_solve',
                      'before_ruc_solve',
-                     'after_operations']
+                     'after_operations',
+                     'after_simulation']
         for cb in callbacks:
             self._setup_callback(cb)
 

--- a/prescient/plugins/internal.py
+++ b/prescient/plugins/internal.py
@@ -26,7 +26,7 @@ class PluginCallbackManager():
                      'before_operations_solve',
                      'before_ruc_solve',
                      'after_operations',
-                     'after_simulation']
+                     'finalization']
         for cb in callbacks:
             self._setup_callback(cb)
 

--- a/prescient/plugins/plugin_registration.py
+++ b/prescient/plugins/plugin_registration.py
@@ -104,10 +104,10 @@ def register_update_operations_stats_callback(callback: Callable[[Options, Simul
     '''
     get_active_plugin_manager().register_update_operations_stats_callback(callback)
 
-def register_after_simulation_callback(callback: Callable[[Options, Simulator], None]) -> None:
+def register_finalization_callback(callback: Callable[[Options, Simulator], None]) -> None:
     ''' Request a method be called after prescient simulation is over.
     '''
-    get_active_plugin_manager().register_after_simulation_callback(callback)
+    get_active_plugin_manager().register_finalization_callback(callback)
 
 
 

--- a/prescient/plugins/plugin_registration.py
+++ b/prescient/plugins/plugin_registration.py
@@ -69,17 +69,17 @@ def register_before_ruc_solve_callback(callback: Callable[[Options, Simulator, R
 def register_after_ruc_generation_callback(callback: Callable[[Options, Simulator, RucPlan, str, int], None]) -> None:
     ''' Register a callback to be called after each new RUC pair is generated.
 
-        The callback is called after both the forecast and actuals RUCs have been 
+        The callback is called after both the forecast and actuals RUCs have been
         generated, just before they are stored in the DataManager.
     '''
     get_active_plugin_manager().register_after_ruc_generation_callback(callback)
-    
+
 def register_after_ruc_activation_callback(callback: Callable[[Options, Simulator], None]):
     ''' Register a callback to be called after activating a RUC.
 
         The callback is called just after the most recently generated RUC
         pair becomes the active RUC pair.  The new RUC instances are
-        accessible through the data manager 
+        accessible through the data manager
         (ex: simulator.data_manager.deterministic_ruc_instance_for_this_period).
     '''
     get_active_plugin_manager().register_after_ruc_activation_callback(callback)
@@ -99,10 +99,15 @@ def register_after_operations_callback(callback: Callable[[Options, Simulator, O
     get_active_plugin_manager().register_after_operations_callback(callback)
 
 def register_update_operations_stats_callback(callback: Callable[[Options, Simulator, OperationsStats], None]) -> None:
-    ''' Register a callback to be called after intial statistics have been gathered for an 
+    ''' Register a callback to be called after intial statistics have been gathered for an
         solved operations model, but before the statistics have been published.
     '''
     get_active_plugin_manager().register_update_operations_stats_callback(callback)
+
+def register_after_simulation_callback(callback: Callable[[Options, Simulator], None]) -> None:
+    ''' Request a method be called after prescient simulation is over.
+    '''
+    get_active_plugin_manager().register_after_simulation_callback(callback)
 
 
 
@@ -129,7 +134,7 @@ def register_before_new_actuals_ruc_callback(callback):
     ''' Register a callback to be called just before an actuals RUC is generated.
 
         The callback will be called once for each actuals RUC.  It is called after
-        the corresponding forecast RUC has been created and solved, but before the 
+        the corresponding forecast RUC has been created and solved, but before the
         actuals RUC is created and solved.
     '''
     raise RuntimeError("This callback is not yet implemented")

--- a/prescient/simulator/simulator.py
+++ b/prescient/simulator/simulator.py
@@ -105,7 +105,7 @@ class Simulator:
 
         stats_manager.end_simulation()
 
-        self.plugin_manager.invoke_after_simulation_callbacks(options, self)
+        self.plugin_manager.invoke_finalization_callbacks(options, self)
 
         print("Simulation Complete")
         import time

--- a/prescient/simulator/simulator.py
+++ b/prescient/simulator/simulator.py
@@ -24,8 +24,8 @@ import prescient.plugins
 class Simulator:
 
     def __init__(self, model_engine: ModelingEngine,
-                       time_manager: TimeManager, 
-                       data_manager: DataManager, 
+                       time_manager: TimeManager,
+                       data_manager: DataManager,
                        oracle_manager: OracleManager,
                        stats_manager: StatsManager,
                        reporting_manager: ReportingManager
@@ -46,7 +46,7 @@ class Simulator:
             raise RuntimeError("The stats_manager must be an instance of class simulator.StatsManager")
         if not isinstance(model_engine, ModelingEngine):
             raise RuntimeError("The model_engine must be an instance of class simulator.ModelingEngine")
-        
+
         time_manager.set_simulator(self)
         data_manager.set_simulator(self)
         oracle_manager.set_simulator(self)
@@ -104,6 +104,8 @@ class Simulator:
             stats_manager.end_timestep(time_step)
 
         stats_manager.end_simulation()
+
+        self.plugin_manager.invoke_after_simulation_callbacks(options, self)
 
         print("Simulation Complete")
         import time

--- a/tests/simulator_tests/test_cases/test_plugin.py
+++ b/tests/simulator_tests/test_cases/test_plugin.py
@@ -55,3 +55,7 @@ pplugins.register_after_operations_callback(after_operations_callback)
 def update_operations_stats_callback(options, simulator, operations_stats):
     msg('update_operations_stats_callback', options)
 pplugins.register_update_operations_stats_callback(update_operations_stats_callback)
+
+def finalization_callback(options, simulator):
+    msg('finalization_callback', options)
+pplugins.register_finalization_callback(finalization_callback)


### PR DESCRIPTION
Hi @bknueven, would you mind looking at this PR? This PR add a plugin point after Prescient's simulation is over. This will provide plugin objects, e.g., bidder and tracker, opportunities to write their simulation results on the disk after the simulation is done. I would really appreciate your feedback! Thanks!