### PR TITLE
Relaxing sanity check in day-ahead pricing

### DIFF
--- a/prescient/engine/egret/egret_plugin.py
+++ b/prescient/engine/egret/egret_plugin.py
@@ -500,7 +500,9 @@ def solve_deterministic_day_ahead_pricing_problem(solver, ruc_results, options, 
 
     ## Debugging
     if pricing_results.data['system']['total_cost'] > ruc_results.data['system']['total_cost'] and not \
-            math.isclose(pricing_results.data['system']['total_cost'],  ruc_results.data['system']['total_cost']):
+            math.isclose(pricing_results.data['system']['total_cost'],
+                         ruc_results.data['system']['total_cost'],
+                         rel_tol=1e-06, abs_tol=1e-06):
         print("The pricing run had a higher objective value than the MIP run. This is indicative of a bug.")
         print(f"pricing run cost: {pricing_results.data['system']['total_cost']}")
         print(f"MIP run cost    : {ruc_results.data['system']['total_cost']}")


### PR DESCRIPTION
This is sometimes stopping Prescient execution unnecessarily, e.g., the difference in objectives is within numerical tolerances (note the defaults for `math.isclose` are `rel_tol=1e-09` and `abs_tol=0.0`). This provides more optimization-solver friendly tolerances.

We could also consider eliminating this check altogether. This is the second time I am modifying to to eliminate false positives.