### PR TITLE
Violation should be in absolute value -- 'negative' violations usuall…

### DIFF
--- a/prescient/simulator/reporting_manager.py
+++ b/prescient/simulator/reporting_manager.py
@@ -198,7 +198,7 @@ class ReportingManager(_Manager):
                         'Minute': lambda ops,l: ops.timestamp.minute,
                         'Line': lambda ops,l: l,
                         'Flow': lambda ops,l: _round(ops.observed_flow_levels[l]),
-                        'Violation': lambda ops,l: _round(ops.observed_flow_violation_levels[l]),
+                        'Violation': lambda ops,l: _round(abs(ops.observed_flow_violation_levels[l])),
                    }
         line_writer = CsvMultiRowReporter.from_dict(line_file, line_entries_per_hour, line_columns)
         stats_manager.register_for_sced_stats(line_writer.write_record)
@@ -215,7 +215,7 @@ class ReportingManager(_Manager):
                         'Contingency': lambda ops,c_l: c_l[0],
                         'Line': lambda ops,c_l: c_l[1],
                         'Flow': lambda ops,c_l: _round(ops.observed_contingency_flow_levels[c_l]),
-                        'Violation': lambda ops,c_l: _round(ops.observed_contingency_flow_violation_levels[c_l]),
+                        'Violation': lambda ops,c_l: _round(abs(ops.observed_contingency_flow_violation_levels[c_l])),
                    }
         line_writer = CsvMultiRowReporter.from_dict(line_file, line_entries_per_hour, line_columns)
         stats_manager.register_for_sced_stats(line_writer.write_record)


### PR DESCRIPTION
…y mean the constraint is satisfied

Currently violations which are exceeded "backwards" flow are reported as "negative violation". I think it's better to just report the absolute value.