### PR TITLE
Update instructions to test prescient and install CBC

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,13 @@ solver is not available we recommend installing the open source CBC MILP solver.
 
 #### CBC
 
-On Windows, Linux, and Mac platforms, CBC can be installed using 
-Anaconda:
+On Linux and Mac platforms, CBC can be installed using Anaconda:
 
 ```
 conda install -c conda-forge coincbc
 ```
 
-Binaries for additional platforms may be available from https://github.com/coin-or/Cbc/releases.
+Binaries for additional platforms, including Windows, may be available from https://github.com/coin-or/Cbc/releases.
 
 #### CPLEX
 Instructions for installing Python bindings for CPLEX can be found [here](https://www.ibm.com/support/knowledgecenter/en/SSSA5P_12.8.0/ilog.odms.cplex.help/CPLEX/GettingStarted/topics/set_up/Python_setup.html).

--- a/doc/OnlineDocs/source/tasks/install.rst
+++ b/doc/OnlineDocs/source/tasks/install.rst
@@ -24,13 +24,15 @@ Prescient requires a mixed-integer linear programming (MILP) solver that is comp
 and commercial solvers such as CPLEX, Gurobi, or Xpress.
 
 The specific mechanics of installing a solver is specific to the solver and/or the platform. An easy way to
-install an open source solver on Windows, Linux, and Mac is to install the CBC Anaconda package into the 
+install an open source solver on Linux and Mac is to install the CBC Anaconda package into the 
 current conda environment::
 
 	conda install -c conda-forge coincbc
 
 .. tip::
    Be sure to activate the correct python environment before running the command above.
+
+Binaries for Windows and other platforms may be available from https://github.com/coin-or/Cbc/releases.
 
 Note that the CBC solver is used in most Prescient tests, so you may want to install it even if
 you intend to use another solver in your own runs.
@@ -106,7 +108,8 @@ Verify your installation
 ------------------------
 Prescient is packaged with tests to verify it has been set up correctly. To execute the tests, issue the following command::
 
-	python -m unittest tests/simulator_tests/test_sim_rts_mod.py
+	pytest -v prescient/simulator/tests/test_simulator.py
 
 This command runs the tests using the CBC solver and will fail if you haven't installed CBC. The tests can take
 as long as 30 minutes to run, depending on your machine. If Prescient was installed correctly then all tests should pass.
+


### PR DESCRIPTION
Addresses #134. One thing we still ought to address is to reference the tutorial jupyter notebook instead of the RTS-GMLC downloader. I opened a new issue for that, #157.