### PR TITLE
Remove unused parameter from example input

### DIFF
--- a/examples/5bus/simulation_objects.csv
+++ b/examples/5bus/simulation_objects.csv
@@ -1,5 +1,4 @@
 Simulation_Parameters,Description,DAY_AHEAD,REAL_TIME
-Periods_per_Step,the number of discrete periods represented in each simulation step,24,1
 Period_Resolution,seconds per period,3600,300
 Date_From,simulation beginning period,01/01/2020 0:00,01/01/2020 0:00
 Date_To,simulation ending period (must account for lookahed data availability),12/31/2020 0:00,12/31/2020 0:00


### PR DESCRIPTION
We don't use the Periods_per_Step simulation parameter found in RTS-GMLC input. Its presence in our example confused one of our users.