### PR TITLE
Make "persist forecast errors" the default

### DIFF
--- a/prescient/data/simulation_state/mutable_simulation_state.py
+++ b/prescient/data/simulation_state/mutable_simulation_state.py
@@ -179,7 +179,7 @@ class MutableSimulationState(SimulationState):
         is used to set up the initial simulation state with no offset.
         '''
  
-        ruc_delay = -(options.ruc_execution_hour % (-options.ruc_every_hours))
+        ruc_delay = options.ruc_delay
 
         # If we've never stored a RUC before...
         first_ruc = (len(self._init_gen_state) == 0)
@@ -261,7 +261,7 @@ class MutableSimulationState(SimulationState):
 
 def _save_forecastables(options, model, where_to_store, steps_per_hour):
     first_data = (len(where_to_store) == 0)
-    ruc_delay = -(options.ruc_execution_hour % (-options.ruc_every_hours))
+    ruc_delay = options.ruc_delay
     max_length = steps_per_hour*(ruc_delay + options.ruc_horizon)
 
     # Save all forecastables, indexed by unique forecastable key

--- a/prescient/engine/egret/egret_plugin.py
+++ b/prescient/engine/egret/egret_plugin.py
@@ -409,7 +409,7 @@ def create_deterministic_ruc(options,
                                               60, md)
 
     # Make some near-term forecasts more accurate
-    ruc_delay = -(options.ruc_execution_hour%(-options.ruc_every_hours))
+    ruc_delay = options.ruc_delay
     if options.ruc_prescience_hour > ruc_delay:
         improved_hour_count = options.ruc_prescience_hour - ruc_delay
         for forecastable, forecast in get_forecastables(md):

--- a/prescient/simulator/config.py
+++ b/prescient/simulator/config.py
@@ -197,10 +197,9 @@ class PrescientConfig(ConfigDict):
 
         self.declare("run_sced_with_persistent_forecast_errors", ConfigValue(
             domain=bool,
-            default=False,
-            description="Create all SCED instances assuming persistent forecast error, "
-                        "instead of the default prescience.",
-        )).declare_as_argument()
+            default=True,
+            description="Create all SCED instances assuming persistent forecast errors.",
+        )).declare_as_argument(action='store_true')
 
         self.declare("ruc_prescience_hour", ConfigValue(
             domain=NonNegativeInt,

--- a/prescient/simulator/config.py
+++ b/prescient/simulator/config.py
@@ -595,6 +595,11 @@ class PrescientConfig(ConfigDict):
         self.import_argparse(args)
         return self
 
+    @property
+    def ruc_delay(self) -> int:
+        ''' Get the number of hours before each RUC goes into effect that it is generated '''
+        return -(self.ruc_execution_hour % (-self.ruc_every_hours))
+
 
 
 class _InEnumStr(InEnum):

--- a/prescient/simulator/oracle_manager.py
+++ b/prescient/simulator/oracle_manager.py
@@ -39,7 +39,7 @@ class OracleManager(_Manager):
 
     def _get_ruc_delay(self, options):
         ''' The number of hours between the generation of a RUC plan and when it is activated '''
-        return -(options.ruc_execution_hour % (-options.ruc_every_hours))
+        return options.ruc_delay
 
     def _get_uc_activation_time(self, options, time_step):
         ''' Get the hour and date that a RUC generated at the given time will be activated '''


### PR DESCRIPTION
The config option run_sced_with_persistent_forecast_errors has always defaulted to false, but the most common desired value is true. This PR changes the default to true.