### PR TITLE
Ensure enough data is parsed to satisfy RUC and SCED horizons

### DIFF
--- a/doc/OnlineDocs/source/reference/file_formats/rts-gmlc/simulation_objects.rst
+++ b/doc/OnlineDocs/source/reference/file_formats/rts-gmlc/simulation_objects.rst
@@ -36,37 +36,6 @@ The following values of :col:`Simulation_Parameter` are supported:
        files
      - The number of seconds between values in *REAL_TIME* timeseries data
        files
-   * - *Date_From*
-     - Yes
-     - The date and time of the first value in each timeseries data file.
-       Most reasonable formats are accepted.
-     - The date and time of the first value in each DAY_AHEAD timeseries data
-       file
-     - The date and time of the first value in each REAL_TIME timeseries data
-       file
-   * - *Date_To*
-     - Yes
-     - The latest date and time for which we have enough data in timeseries
-       files to formulate a RUC or SCED. Most reasonable formats are
-       accepted. See `Date_To Details`_ below.
-     - The latest date and time for which we have enough data in DAY_AHEAD
-       timeseries data files to formulate a RUC
-     - The latest date and time for which we have enough data in REAL_TIME
-       timeseries data files to formulate a SCED
-   * - *Look_Ahead_Periods_Per_Step*
-     - Yes
-     - The default number of look-ahead periods to use in RUC or SCED formulations
-     - The default number of look-ahead periods to use in RUC formulations
-     - The default number of look-ahead periods to use in SCED formulations
-   * - *Look_Ahead_Resolution*
-     - Yes
-     - The default number of seconds between each look-ahead period used in
-       RUC or SCED formulations. See `Look_Ahead_Resolution Details`_ below.
-     - The default number of seconds between each look-ahead period in RUC
-       formulations
-     - The default number of seconds between each look-ahead period in SCED
-       formulations
-       formulations
    * - *Reserve_Products*
      - No
      - Which reserve products to enforce for RUC plans or SCED operations.
@@ -74,32 +43,6 @@ The following values of :col:`Simulation_Parameter` are supported:
      - Which reserve products to enforce for RUC plans
      - Which reserve products to enforce for SCED operations
 
-
-Date_To Details
-~~~~~~~~~~~~~~~
-
-The value of *Date_To* identifies the latest time for which there is
-enough data to formulate or RUC (for :col:`DAY_AHEAD`) or SCED (for
-:col:`REAL_TIME`), including look-ahead periods. This is not the date
-and time of the final value in timeseries data files. Instead, the
-*Date_To* is *Look_Ahead_Periods_Per_Step \* Look_Ahead_Resolution*
-before the date and time of the final value in the timeseries data files.
-
-For example, consider a data set with 24 look-ahead periods with a
-look-ahead resolution of 1 hour. If the final value in a timeseries is
-for April 10\ :sup:`th` at midnight, then *Date_To* is April 9\ :sup:`th`
-at midnight, because that is the latest time for which we have enough
-data to satisfy the 24 hour look-ahead requirement.
-
-Look_Ahead_Resolution Details
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The *Look_Ahead_Resolution* parameter is used to determine the date and time of the
-final value in timeseries data files, as described in `Date_To Details`_. Despite its
-name, it is not used to specify the look-ahead resolution used during simulation. The
-actual look-ahead resolution used during simulation is determined by configuration parameters
-passed to Prescient. Prescient will interpolate the available data as necessary to
-honor the look-ahead resolution specified in its configuration parameters.
 
 Reserve_Products Details
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(name='gridx-prescient',
                     'prescient.simulator.tests':['regression_tests_data/**/*'],
                    },
       install_requires=['numpy','matplotlib','pandas','scipy','pyomo>=6.1.2',
-                        'python-dateutil','networkx','jupyter', 'gridx-egret==0.5.5',
+                        'python-dateutil','networkx','jupyter', 'gridx-egret==0.5.6.dev0',
                        ],
      )


### PR DESCRIPTION
Previously, Egret relied on look-ahead information in the CSV files to decide how much data to parse beyond the end date. If the horizons used by Prescient exceeded the look-ahead parameters in the CSV, Egret would parse less data than Prescient needs. In this PR, Prescient extends the end time by the required amount of time and then tells Egret not to extend the end time further than it's already been extended. It essentially gives Prescient total control over the range of date read by Egret.