### PR TITLE
Fix online documentation build on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,10 @@ sphinx:
 
 formats: all
 
+python:
+  install:
+    - requirements: doc/OnlineDocs/requirements.txt
+
 # Set the version of Python and requirements required to build the docs
 #python:
 #  version: 3

--- a/doc/OnlineDocs/requirements.txt
+++ b/doc/OnlineDocs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme


### PR DESCRIPTION
The sphinx-rtd-theme is no longer automatically installed on ReadTheDocs. Add it as an explicit dependency.