### PR TITLE
Isolate scheduled tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,19 +1,7 @@
-name: GitHub CI
+name: Run Tests
 
 on:
-    # Trigger the workflow on push or pull request,
-    # but only for the main branch
-    push:
-        branches:
-            - main
-    pull_request:
-        branches:
-            - main
-    # nightly tests at 8:00 UTC
-    schedule:
-        - cron:  '0 8 * * *'
-    workflow_dispatch:
-         types: run-test
+    workflow_call:
 
 defaults:
     run:
@@ -91,3 +79,4 @@ jobs:
           - name: Run Prescient Simulator Tests
             run: |
               pytest -v prescient/simulator/tests/test_simulator.py
+

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -1,0 +1,18 @@
+name: Test Changes
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  # Allow it to be manually triggered as well
+  workflow_dispatch:
+
+jobs:
+  call-run-tests:
+    uses: ./.github/workflows/run-tests.yml
+

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -1,0 +1,10 @@
+name: Weekly Tests
+
+on:
+  schedule:
+    - cron: 58 7 * * 0
+
+jobs:
+  call-run-tests:
+    uses: ./.github/workflows/run-tests.yml
+


### PR DESCRIPTION
GitHub disables workflows with a `schedule` trigger if you go too long without making changes. When the workflow is disabled, it appears to disable all triggers, not just the schedule trigger. This PR is an attempt to avoid that by splitting the CI workflow into two, one for scheduled triggers and one for everything else.